### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/neon_workflow.yml
+++ b/.github/workflows/neon_workflow.yml
@@ -1,4 +1,6 @@
 name: Create/Delete Branch for Pull Request
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Johnthesuper117/bytelabs.online/security/code-scanning/5](https://github.com/Johnthesuper117/bytelabs.online/security/code-scanning/5)

The best way to fix the problem is to add an explicit `permissions` key to the root of the workflow, specifying least privilege required for the jobs. None of the jobs require repository write access, unless the user later uncomments or adds write operations (like posting PR comments). For current uncommented steps, it's safest to specify `contents: read` at the root level. Since the only possible future write scope would be `pull-requests: write` (for posting schema diff comments), but it's not in use by default, we can omit it for now. Place the `permissions:` block immediately after the workflow `name:` block, spanning lines 2-3.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
